### PR TITLE
Feat/n divide

### DIFF
--- a/src/model/OCR/tesseract_OCR.py
+++ b/src/model/OCR/tesseract_OCR.py
@@ -94,7 +94,7 @@ class Tesseract_OCR:
                 for order, tx in enumerate(txt):
                     flag = 0
                     if order == len(txt) -1 or order == 0:
-                        flag = 2
+                        flag = 1.5
                         
                     if tx.isalpha():
                         char_width = np.append(char_width,10 + flag)
@@ -103,7 +103,7 @@ class Tesseract_OCR:
                         char_width = np.append(char_width,6 + flag)
                         char_true.append(False)
                     elif tx in "!., ":
-                        char_width = np.append(char_width,2)
+                        char_width = np.append(char_width,3.3 + flag)
                         char_true.append(False)
                         
                 char_width *= (x2-x1) / np.sum(char_width)


### PR DESCRIPTION

## Overview

- rule base divide 고도화
- 첫 글자나 마지막 글자는 OCR 될 때 여유 부분이 생김(특수 경우)
- 특수문자는 일반 문자에 비해 차지하는 공간이 적음

비율
|일반 문자|?  ~  ^|!  , .  (공백)|비고|
|------|---|---|---------|
|10.0|6.0|3.3|특수 경우일때 + 1.5

<br>

## Change Log

- tesseract_OCR에서 n_divide의 rule 고도화

<br>

## To Reviewer

일반적인 경우에는 잘 된다
![3](https://user-images.githubusercontent.com/62556539/216003779-1d80d7fd-e97d-4185-a368-4efe5049cb34.png)


<br>
